### PR TITLE
Initialize scaffold for MarketPipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# MarketPipe
+
+MarketPipe is a lightweight, Python-native ETL framework focused on time
+series market data.  It aims to provide a simple command line interface
+for ingesting, aggregating and validating OHLCV data with baked in
+DuckDB/Parquet storage.  The project is still in early scaffolding.
+
+```mermaid
+flowchart TD
+    subgraph Universe
+        U0["Weekly Universe Refresh (Cboe + OCC scrape)"] --> U1["Filtered Tickers (universe-YYYY-MM-DD.csv)"]
+    end
+    subgraph DailyPipeline
+        subgraph Ingestion
+            I0["Daily Ingest (1-min OHLCV, Finnhub API)"] --> I1["Raw Parquet Storage: frame=1m/symbol/date"]
+            BF["Backfill Historical OHLCV (--start, --end)"] --> I1
+        end
+
+        subgraph Aggregation
+            A0["Aggregate to 5m, 15m, 1h, 1d (DuckDB SQL)"] --> A1["Write Aggregated Parquet: frame=Xm/symbol/date"]
+        end
+
+        subgraph Validation
+            V0["Validate 1d Close vs Polygon API"] --> V1["Validation Report CSV"]
+            V1 --> QA["Emit QA Metrics"]
+        end
+    end
+
+    subgraph Loader
+        L0["load_ohlcv()"]
+        L0 --> DB0["DuckDB parquet_scan"]
+        DB0 --> DF["Filtered DataFrame (timestamp, symbol)"]
+    end
+
+    subgraph Schedule
+        CRON1["18:10 ET → Ingest"] --> I0
+        CRON2["18:20 ET → Aggregate"] --> A0
+        CRON3["18:30 ET → Validate"] --> V0
+        CRON4["Thu 20:00 ET → Universe Refresh"] --> U0
+    end
+
+    I1 --> A0
+    A1 --> V0
+    DF --> Quant["Signal/Backtest Consumers"]
+    QA --> Quant
+```
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+marketpipe --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "marketpipe"
+version = "0.1.0"
+description = "Lightweight CLI-based ETL for market data"
+readme = "README.md"
+authors = [{name = "MarketPipe"}]
+requires-python = ">=3.9"
+dependencies = [
+    "typer[all]",
+    "pandas",
+    "duckdb",
+    "pyarrow",
+    "requests"
+]
+
+[project.scripts]
+marketpipe = "marketpipe.cli:app"

--- a/src/marketpipe/__init__.py
+++ b/src/marketpipe/__init__.py
@@ -1,0 +1,3 @@
+"""MarketPipe package initialization."""
+
+__all__ = ["cli", "ingestion", "aggregation", "validation", "loader"]

--- a/src/marketpipe/aggregation.py
+++ b/src/marketpipe/aggregation.py
@@ -1,0 +1,6 @@
+"""Aggregation stubs."""
+
+
+def aggregate() -> None:
+    """Placeholder for aggregation step."""
+    print("Aggregating raw data ...")

--- a/src/marketpipe/cli.py
+++ b/src/marketpipe/cli.py
@@ -1,0 +1,29 @@
+"""Command line interface for MarketPipe."""
+
+import typer
+from . import ingestion, aggregation, validation
+
+app = typer.Typer(add_completion=False, help="MarketPipe ETL commands")
+
+
+@app.command()
+def ingest(start: str | None = typer.Option(None, help="Start date YYYY-MM-DD"),
+           end: str | None = typer.Option(None, help="End date YYYY-MM-DD")):
+    """Ingest daily or historical OHLCV data."""
+    ingestion.ingest(start=start, end=end)
+
+
+@app.command()
+def aggregate():
+    """Aggregate raw data into coarser time frames."""
+    aggregation.aggregate()
+
+
+@app.command()
+def validate():
+    """Validate aggregated data against a reference API."""
+    validation.validate()
+
+
+if __name__ == "__main__":
+    app()

--- a/src/marketpipe/ingestion.py
+++ b/src/marketpipe/ingestion.py
@@ -1,0 +1,12 @@
+"""Data ingestion stubs."""
+
+from datetime import date
+
+
+def ingest(start: str | None = None, end: str | None = None) -> None:
+    """Placeholder for daily or historical ingestion."""
+    if start and end:
+        print(f"Backfilling data from {start} to {end} ...")
+    else:
+        today = date.today().isoformat()
+        print(f"Ingesting data for {today} ...")

--- a/src/marketpipe/loader.py
+++ b/src/marketpipe/loader.py
@@ -1,0 +1,6 @@
+"""Loader stubs."""
+
+
+def load_ohlcv(symbol: str):
+    """Placeholder for loading data from DuckDB/Parquet."""
+    print(f"Loading data for {symbol} ...")

--- a/src/marketpipe/validation.py
+++ b/src/marketpipe/validation.py
@@ -1,0 +1,6 @@
+"""Validation stubs."""
+
+
+def validate() -> None:
+    """Placeholder for validation step."""
+    print("Validating data against Polygon API ...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def test_help():
+    result = subprocess.run([
+        'python', '-m', 'marketpipe.cli', '--help'
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'MarketPipe ETL commands' in result.stdout


### PR DESCRIPTION
## Summary
- add basic project README including architecture diagram
- set up Python packaging in `pyproject.toml`
- implement stubbed `marketpipe` package and Typer CLI
- add minimal test for the CLI

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dd8cfddc8323b025f749eda51b1f