### PR TITLE
feat: AlpacaClient (schema v1)

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,0 +1,6 @@
+alpaca:
+  # Recommend loading credentials from environment variables for security
+  key: ${ALPACA_KEY}
+  secret: ${ALPACA_SECRET}
+  base_url: https://data.sandbox.alpaca.markets/v2
+  rate_limit_per_min: 200

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,9 @@
+# Connector Notes
+
+## Alpaca
+
+* Endpoint: `GET https://data.sandbox.alpaca.markets/v2/stocks/{symbol}/bars`
+* Auth: headers `APCA-API-KEY-ID` / `APCA-API-SECRET-KEY`
+* Credentials should be provided via environment variables `ALPACA_KEY` and `ALPACA_SECRET`
+* Sandbox rate limit: 200 requests/min (burst 100)
+* Pagination token field: `next_page_token` (supply as `page_token`)

--- a/examples/alpaca_demo_async.py
+++ b/examples/alpaca_demo_async.py
@@ -1,0 +1,31 @@
+import os
+import asyncio
+import datetime as dt
+
+from marketpipe.ingestion.connectors import ClientConfig, RateLimiter, HeaderTokenAuth
+from marketpipe.ingestion.connectors.alpaca_client import AlpacaClient
+
+
+async def main() -> None:
+    key = os.environ["ALPACA_KEY"]
+    secret = os.environ["ALPACA_SECRET"]
+
+    cfg = ClientConfig(
+        api_key=key,
+        base_url="https://data.sandbox.alpaca.markets/v2",
+        rate_limit_per_min=200,
+    )
+
+    auth = HeaderTokenAuth(key, secret)
+    limiter = RateLimiter()
+    client = AlpacaClient(config=cfg, auth=auth, rate_limiter=limiter)
+
+    start = int((dt.datetime.utcnow() - dt.timedelta(days=1)).timestamp() * 1000)
+    end = int(dt.datetime.utcnow().timestamp() * 1000)
+
+    rows = await client.async_fetch_batch("AAPL", start, end)
+    print(len(rows))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/alpaca_demo_sync.py
+++ b/examples/alpaca_demo_sync.py
@@ -1,0 +1,24 @@
+import os
+import datetime as dt
+
+from marketpipe.ingestion.connectors import ClientConfig, RateLimiter, HeaderTokenAuth
+from marketpipe.ingestion.connectors.alpaca_client import AlpacaClient
+
+key = os.environ["ALPACA_KEY"]
+secret = os.environ["ALPACA_SECRET"]
+
+cfg = ClientConfig(
+    api_key=key,
+    base_url="https://data.sandbox.alpaca.markets/v2",
+    rate_limit_per_min=200,
+)
+
+auth = HeaderTokenAuth(key, secret)
+limiter = RateLimiter()
+client = AlpacaClient(config=cfg, auth=auth, rate_limiter=limiter)
+
+start = int((dt.datetime.utcnow() - dt.timedelta(days=1)).timestamp() * 1000)
+end = int(dt.datetime.utcnow().timestamp() * 1000)
+
+rows = client.fetch_batch("AAPL", start, end)
+print(len(rows))

--- a/src/marketpipe/ingestion/connectors/__init__.py
+++ b/src/marketpipe/ingestion/connectors/__init__.py
@@ -1,0 +1,14 @@
+"""Connector exports for easy access."""
+
+from .auth import TokenAuth, HeaderTokenAuth
+from .base_api_client import BaseApiClient, ClientConfig
+from .rate_limit import RateLimiter
+
+__all__ = [
+    "TokenAuth",
+    "HeaderTokenAuth",
+    "BaseApiClient",
+    "ClientConfig",
+    "RateLimiter",
+]
+

--- a/src/marketpipe/ingestion/connectors/alpaca_client.py
+++ b/src/marketpipe/ingestion/connectors/alpaca_client.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+import random
+import time
+from typing import Any, Dict, List, Mapping, Optional
+
+import httpx
+
+from .base_api_client import BaseApiClient
+from .models import ClientConfig
+from .rate_limit import RateLimiter
+from .auth import HeaderTokenAuth
+
+
+ISO_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+class AlpacaClient(BaseApiClient):
+    """Alpaca Data v2 minute-bar connector (sandbox)."""
+
+    _PATH_TEMPLATE = "/stocks/{symbol}/bars"
+
+    # ---------- URL helpers ----------
+    def endpoint_path(self) -> str:
+        return self._PATH_TEMPLATE
+
+    def build_request_params(
+        self,
+        symbol: str,
+        start_ts: int,
+        end_ts: int,
+        cursor: Optional[str] = None,
+    ) -> Mapping[str, str]:
+        start = dt.datetime.utcfromtimestamp(start_ts / 1_000).strftime(ISO_FMT)
+        end = dt.datetime.utcfromtimestamp(end_ts / 1_000).strftime(ISO_FMT)
+        qp: Dict[str, str] = {
+            "symbol": symbol,
+            "timeframe": "1Min",
+            "start": start,
+            "end": end,
+            "limit": "10000",
+        }
+        if cursor:
+            qp["page_token"] = cursor
+        return qp
+
+    def next_cursor(self, raw_json: Dict[str, Any]) -> Optional[str]:
+        return raw_json.get("next_page_token")
+
+    # ---------- sync request ----------
+    def _request(self, params: Mapping[str, str]) -> Dict[str, Any]:
+        if self.rate_limiter:
+            self.rate_limiter.acquire()
+
+        url = f"{self.config.base_url}{self._PATH_TEMPLATE.format(symbol=params['symbol'])}"
+        headers = {"Accept": "application/json", "User-Agent": self.config.user_agent}
+        self.auth.apply(headers, params={})
+
+        retries = 0
+        while True:
+            r = httpx.get(
+                url,
+                params={k: v for k, v in params.items() if k != "symbol"},
+                headers=headers,
+                timeout=self.config.timeout,
+            )
+            if not self.should_retry(r.status_code, r.json()):
+                return r.json()
+
+            retries += 1
+            if retries > self.config.max_retries:
+                raise RuntimeError(f"Alpaca request exceeded retry limit: {r.text}")
+            sleep = self._backoff(retries)
+            self.log.warning("Retry %d sleeping %.2fs", retries, sleep)
+            time.sleep(sleep)
+
+    # ---------- async request ----------
+    async def _async_request(self, params: Mapping[str, str]) -> Dict[str, Any]:
+        if self.rate_limiter:
+            await self.rate_limiter.async_acquire()
+
+        url = f"{self.config.base_url}{self._PATH_TEMPLATE.format(symbol=params['symbol'])}"
+        headers = {"Accept": "application/json", "User-Agent": self.config.user_agent}
+        self.auth.apply(headers, params={})
+
+        retries = 0
+        async with httpx.AsyncClient(timeout=self.config.timeout) as client:
+            while True:
+                r = await client.get(
+                    url,
+                    params={k: v for k, v in params.items() if k != "symbol"},
+                    headers=headers,
+                )
+                if not self.should_retry(r.status_code, r.json()):
+                    return r.json()
+
+                retries += 1
+                if retries > self.config.max_retries:
+                    raise RuntimeError("Alpaca async retry limit hit")
+                sleep = self._backoff(retries)
+                self.log.warning("Async retry %d sleeping %.2fs", retries, sleep)
+                await asyncio.sleep(sleep)
+
+    # ---------- parsing ----------
+    def parse_response(self, raw_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        for bar in raw_json.get("bars", []):
+            rows.append(
+                {
+                    "symbol": bar["S"],
+                    "timestamp": int(dt.datetime.fromisoformat(bar["t"]).timestamp() * 1_000_000_000),
+                    "date": dt.date.fromisoformat(bar["t"][:10]),
+                    "open": bar["o"],
+                    "high": bar["h"],
+                    "low": bar["l"],
+                    "close": bar["c"],
+                    "volume": bar["v"],
+                    "trade_count": bar.get("n"),
+                    "vwap": None,
+                    "session": "regular",
+                    "currency": "USD",
+                    "status": "ok",
+                    "source": "alpaca",
+                    "frame": "1m",
+                    "schema_version": 1,
+                }
+            )
+        return rows
+
+    # ---------- helpers ----------
+    def should_retry(self, status: int, body: Dict[str, Any]) -> bool:
+        if status in {429, 500, 502, 503, 504}:
+            return True
+        if status == 403 and "too many requests" in str(body).lower():
+            return True
+        return False
+
+    @staticmethod
+    def _backoff(attempt: int) -> float:
+        base = 1.5 ** attempt
+        return base + random.uniform(0, 0.2 * base)
+

--- a/src/marketpipe/ingestion/connectors/auth.py
+++ b/src/marketpipe/ingestion/connectors/auth.py
@@ -21,3 +21,15 @@ class TokenAuth(AuthStrategy):
 
     def apply(self, headers: Dict[str, str], params: Dict[str, str]) -> None:
         headers["Authorization"] = f"Bearer {self.token}"
+
+
+class HeaderTokenAuth(AuthStrategy):
+    """Simple header-based auth for Alpaca."""
+
+    def __init__(self, key_id: str, secret_key: str) -> None:
+        self.key_id = key_id
+        self.secret_key = secret_key
+
+    def apply(self, headers: Dict[str, str], params: Dict[str, str]) -> None:
+        headers["APCA-API-KEY-ID"] = self.key_id
+        headers["APCA-API-SECRET-KEY"] = self.secret_key

--- a/src/marketpipe/ingestion/connectors/models.py
+++ b/src/marketpipe/ingestion/connectors/models.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# Path to the canonical OHLCV schema used throughout the package
+SCHEMA_PATH = "schema/schema_v1.json"
+
 
 class ClientConfig(BaseModel):
     """Configuration for API clients."""

--- a/src/marketpipe/ingestion/connectors/rate_limit.py
+++ b/src/marketpipe/ingestion/connectors/rate_limit.py
@@ -11,3 +11,6 @@ class RateLimiter:
     async def acquire_async(self) -> None:
         """Async token acquisition stub."""
         return None
+
+    async def async_acquire(self) -> None:  # backward compat alias
+        return await self.acquire_async()

--- a/tests/test_alpaca_client.py
+++ b/tests/test_alpaca_client.py
@@ -1,0 +1,78 @@
+import types
+
+import httpx
+import pytest
+import asyncio
+
+from marketpipe.ingestion.connectors.alpaca_client import AlpacaClient
+from marketpipe.ingestion.connectors.auth import HeaderTokenAuth
+from marketpipe.ingestion.connectors.models import ClientConfig
+
+
+def test_alpaca_pagination(monkeypatch):
+    pages = [
+        {
+            "bars": [
+                {"S": "AAPL", "t": "2023-01-02T09:30:00", "o": 1, "h": 2, "l": 3, "c": 4, "v": 5}
+            ],
+            "next_page_token": "abc",
+        },
+        {
+            "bars": [
+                {"S": "AAPL", "t": "2023-01-02T09:31:00", "o": 1, "h": 2, "l": 3, "c": 4, "v": 5}
+            ]
+        },
+    ]
+
+    headers_seen = []
+
+    def mock_get(url, params=None, headers=None, timeout=None):
+        headers_seen.append(headers)
+        body = pages.pop(0)
+        return types.SimpleNamespace(status_code=200, json=lambda: body, text=str(body))
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    cfg = ClientConfig(api_key="k", base_url="http://x")
+    auth = HeaderTokenAuth("id", "sec")
+    client = AlpacaClient(config=cfg, auth=auth)
+
+    rows = client.fetch_batch("AAPL", 0, 1)
+
+    assert len(rows) == 2
+    assert headers_seen[0]["APCA-API-KEY-ID"] == "id"
+    assert all(r["schema_version"] == 1 for r in rows)
+
+def test_alpaca_async(monkeypatch):
+    pages = [
+        {
+            "bars": [{"S": "AAPL", "t": "2023-01-02T09:30:00", "o": 1, "h": 2, "l": 3, "c": 4, "v": 5}],
+            "next_page_token": "abc",
+        },
+        {
+            "bars": [{"S": "AAPL", "t": "2023-01-02T09:31:00", "o": 1, "h": 2, "l": 3, "c": 4, "v": 5}]
+        },
+    ]
+    headers_seen = []
+
+    class DummyAsyncClient:
+        def __init__(self, *a, **kw):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, url, params=None, headers=None):
+            headers_seen.append(headers)
+            body = pages.pop(0)
+            return types.SimpleNamespace(status_code=200, json=lambda: body)
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+
+    cfg = ClientConfig(api_key="k", base_url="http://x")
+    auth = HeaderTokenAuth("id", "sec")
+    client = AlpacaClient(config=cfg, auth=auth)
+
+    rows = asyncio.run(client.async_fetch_batch("AAPL", 0, 1))
+    assert len(rows) == 2
+    assert headers_seen[0]["APCA-API-KEY-ID"] == "id"


### PR DESCRIPTION
## Summary
- create HeaderTokenAuth and AlpacaClient
- export new classes from `connectors`
- document and configure Alpaca connector
- provide sync/async demo scripts
- add tests for pagination and async fetch
- document environment variable usage for credentials

## Testing
- `pip install httpx`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841fcf8b1788323aaf36f430f624277