### PR TITLE
Implement ingestion coordinator pipeline

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -4,3 +4,9 @@ alpaca:
   secret: ${ALPACA_SECRET}
   base_url: https://data.sandbox.alpaca.markets/v2
   rate_limit_per_min: 200
+
+output_path: data
+symbols: ["AAPL", "MSFT", "TSLA"]
+start: 2025-06-04
+end: 2025-06-04
+workers: 3

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,22 @@
+# Ingestion Pipeline
+
+The first end-to-end pipeline pulls one trading day of minute bars from
+Alpaca and writes validated Parquet files.  The flow is:
+
+```mermaid
+flowchart LR
+    A[IngestionCoordinator] --> B[AlpacaClient]
+    B --> C[SchemaValidator]
+    C --> D[ParquetWriter]
+    D --> E[SQLite Checkpoint]
+```
+
+Run it from the project root:
+
+```bash
+marketpipe ingest --config config/example_config.yaml
+```
+
+This writes partitioned files like
+`data/symbol=AAPL/year=2025/month=06/day=04.parquet`.
+

--- a/examples/ingest_one_day.py
+++ b/examples/ingest_one_day.py
@@ -1,0 +1,26 @@
+"""Example script running the ingestion CLI."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+CONFIG = HERE.parent / "config" / "example_config.yaml"
+
+
+def main() -> None:
+    subprocess.run([
+        "python",
+        "-m",
+        "marketpipe",
+        "ingest",
+        "--config",
+        str(CONFIG),
+    ], check=True)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "pandas",
     "duckdb",
     "pyarrow",
-    "requests"
+    "requests",
+    "pyyaml"
 ]
 
 [project.scripts]

--- a/src/marketpipe/cli.py
+++ b/src/marketpipe/cli.py
@@ -7,10 +7,9 @@ app = typer.Typer(add_completion=False, help="MarketPipe ETL commands")
 
 
 @app.command()
-def ingest(start: str | None = typer.Option(None, help="Start date YYYY-MM-DD"),
-           end: str | None = typer.Option(None, help="End date YYYY-MM-DD")):
-    """Ingest daily or historical OHLCV data."""
-    ingestion.ingest(start=start, end=end)
+def ingest(config: str = typer.Option(..., "--config", help="Path to YAML config")):
+    """Run the ingestion pipeline."""
+    ingestion.ingest(config)
 
 
 @app.command()

--- a/src/marketpipe/ingestion/__init__.py
+++ b/src/marketpipe/ingestion/__init__.py
@@ -1,12 +1,13 @@
 """Data ingestion stubs."""
 
-from datetime import date
+from .coordinator import IngestionCoordinator
 
 
-def ingest(start: str | None = None, end: str | None = None) -> None:
-    """Placeholder for daily or historical ingestion."""
-    if start and end:
-        print(f"Backfilling data from {start} to {end} ...")
-    else:
-        today = date.today().isoformat()
-        print(f"Ingesting data for {today} ...")
+def ingest(config: str) -> None:
+    """Run the ingestion pipeline from a YAML config."""
+    coord = IngestionCoordinator(config)
+    summary = coord.run()
+    print(
+        f"Ingested {summary['symbols']} symbols, {summary['rows']} rows, "
+        f"wrote {summary['files']} parquet files."
+    )

--- a/src/marketpipe/ingestion/__main__.py
+++ b/src/marketpipe/ingestion/__main__.py
@@ -1,0 +1,20 @@
+"""Module entrypoint for ``python -m marketpipe.ingestion``."""
+
+from __future__ import annotations
+
+import typer
+
+from . import ingest
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def run(config: str = typer.Option(..., "--config", help="Path to YAML config")):
+    ingest(config)
+
+
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
+    app()
+

--- a/src/marketpipe/ingestion/coordinator.py
+++ b/src/marketpipe/ingestion/coordinator.py
@@ -1,0 +1,87 @@
+"""Threaded ingestion coordinator."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .connectors.alpaca_client import AlpacaClient
+from .connectors.models import ClientConfig
+from .connectors.auth import HeaderTokenAuth
+from .connectors.rate_limit import RateLimiter
+from .state import SQLiteState
+from .validator import SchemaValidator
+from .writer import write_parquet
+
+
+class IngestionCoordinator:
+    """Simple orchestration layer that fans out ingest jobs to workers."""
+
+    def __init__(self, config_path: str, state_path: str | None = None) -> None:
+        with open(config_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+
+        self.symbols: List[str] = cfg.get("symbols", [])
+        self.output_root = cfg["output_path"]
+        self.start = dt.datetime.fromisoformat(cfg["start"])
+        self.end = dt.datetime.fromisoformat(cfg["end"])
+        self.workers = cfg.get("workers", len(self.symbols))
+
+        a_cfg = cfg["alpaca"]
+        self.client_cfg = ClientConfig(
+            api_key=a_cfg["key"],
+            base_url=a_cfg["base_url"],
+            rate_limit_per_min=a_cfg.get("rate_limit_per_min"),
+        )
+        self.auth = HeaderTokenAuth(a_cfg["key"], a_cfg["secret"])
+        self.state = SQLiteState(Path(state_path) if state_path else None)
+
+        self.validator = SchemaValidator()
+
+    # ---------------------------------------------------------------
+    def _process_symbol(self, symbol: str) -> int:
+        limiter = RateLimiter()
+        client = AlpacaClient(
+            config=self.client_cfg,
+            auth=self.auth,
+            rate_limiter=limiter,
+            state_backend=self.state,
+        )
+
+        end_ms = int(self.end.timestamp() * 1000)
+        end_ns = end_ms * 1_000_000
+        start_ms = int(self.start.timestamp() * 1000)
+
+        checkpoint = self.state.get(symbol)
+        if checkpoint is not None and checkpoint >= end_ns:
+            return 0
+
+        rows = client.fetch_batch(symbol, start_ms, end_ms)
+        if not rows:
+            return 0
+
+        self.validator.validate_batch(rows)
+        write_parquet(rows, self.output_root, overwrite=True)
+
+        last_ts = max(r["timestamp"] for r in rows)
+        self.state.set(symbol, last_ts)
+        return len(rows)
+
+    # ---------------------------------------------------------------
+    def run(self) -> Dict[str, int]:
+        total_rows = 0
+        with ThreadPoolExecutor(max_workers=self.workers) as pool:
+            results = list(pool.map(self._process_symbol, self.symbols))
+        total_rows = sum(results)
+        summary = {
+            "symbols": len(self.symbols),
+            "rows": total_rows,
+            "files": len(self.symbols),
+        }
+        return summary
+

--- a/src/marketpipe/ingestion/state.py
+++ b/src/marketpipe/ingestion/state.py
@@ -1,0 +1,41 @@
+"""SQLite checkpoint helper."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_PATH = Path.home() / ".marketpipe_state.db"
+
+
+class SQLiteState:
+    """Very small wrapper around a SQLite DB for checkpoints."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = Path(db_path or DEFAULT_PATH)
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoints("
+                "symbol TEXT PRIMARY KEY, last_ts INTEGER)"
+            )
+
+    def get(self, symbol: str) -> Optional[int]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                "SELECT last_ts FROM checkpoints WHERE symbol=?", (symbol,)
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def set(self, symbol: str, ts: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO checkpoints(symbol, last_ts) VALUES (?, ?)",
+                (symbol, ts),
+            )
+

--- a/src/marketpipe/ingestion/validator.py
+++ b/src/marketpipe/ingestion/validator.py
@@ -1,0 +1,59 @@
+"""Row validation utilities for the ingestion pipeline."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ValidationError
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / "schema" / "schema_v1.json"
+
+with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+    _SCHEMA_JSON = json.load(f)
+
+
+class _RowModel(BaseModel):
+    symbol: str
+    timestamp: int
+    date: date
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+    vwap: Optional[float] = None
+    trade_count: Optional[int] = None
+    bid: Optional[float] = None
+    ask: Optional[float] = None
+    spread: Optional[float] = None
+    source: Optional[str] = None
+    exchange: Optional[str] = None
+    frame: Optional[str] = None
+    session: Optional[str] = None
+    currency: Optional[str] = None
+    status: Optional[str] = None
+    adjusted: Optional[bool] = None
+    halted: Optional[bool] = None
+    ingest_id: Optional[str] = None
+    schema_version: int
+
+
+class SchemaValidator:
+    """Validate raw rows against ``schema_v1`` using Pydantic."""
+
+    def __init__(self) -> None:
+        self.schema = _SCHEMA_JSON
+
+    def validate(self, row: Dict[str, Any]) -> None:
+        """Validate a single row in place."""
+        _RowModel(**row)
+
+    def validate_batch(self, rows: List[Dict[str, Any]]) -> None:
+        for r in rows:
+            self.validate(r)
+

--- a/src/marketpipe/ingestion/writer.py
+++ b/src/marketpipe/ingestion/writer.py
@@ -1,0 +1,35 @@
+"""Parquet writing helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Dict, List
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def write_parquet(rows: List[Dict], output_root: str, overwrite: bool = False) -> str:
+    """Write rows to a partitioned Parquet file."""
+    if not rows:
+        raise ValueError("No rows supplied")
+
+    ts = dt.datetime.utcfromtimestamp(rows[0]["timestamp"] / 1_000_000_000)
+    path = os.path.join(
+        output_root,
+        f"symbol={rows[0]['symbol']}",
+        f"year={ts.year:04d}",
+        f"month={ts.month:02d}",
+        f"day={ts.day:02d}.parquet",
+    )
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    if os.path.exists(path) and not overwrite:
+        return path
+
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, path)
+    return path
+

--- a/tests/test_coordinator_flow.py
+++ b/tests/test_coordinator_flow.py
@@ -1,0 +1,80 @@
+import datetime as dt
+from pathlib import Path
+
+import yaml
+import pyarrow.parquet as pq
+
+from marketpipe.ingestion.coordinator import IngestionCoordinator
+
+
+def make_rows(symbol: str) -> list[dict]:
+    rows = []
+    start = dt.datetime(2023, 1, 2, 13, 30)
+    for i in range(10):
+        ts = int(start.timestamp() * 1_000_000_000) + i * 60_000_000_000
+        rows.append(
+            {
+                "symbol": symbol,
+                "timestamp": ts,
+                "date": start.date(),
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 1,
+                "trade_count": 1,
+                "vwap": None,
+                "session": "regular",
+                "currency": "USD",
+                "status": "ok",
+                "source": "alpaca",
+                "frame": "1m",
+                "schema_version": 1,
+            }
+        )
+    return rows
+
+
+def test_coordinator_flow(tmp_path, monkeypatch):
+    cfg = {
+        "alpaca": {"key": "k", "secret": "s", "base_url": "http://x"},
+        "symbols": ["AAPL"],
+        "output_path": str(tmp_path / "data"),
+        "start": "2023-01-02",
+        "end": "2023-01-02",
+        "workers": 1,
+    }
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(yaml.safe_dump(cfg))
+
+    rows = make_rows("AAPL")
+
+    def fake_fetch(self, symbol, start_ts, end_ts):
+        return rows
+
+    monkeypatch.setattr(
+        "marketpipe.ingestion.connectors.alpaca_client.AlpacaClient.fetch_batch",
+        fake_fetch,
+    )
+
+    coord = IngestionCoordinator(str(cfg_file), state_path=str(tmp_path / "state.db"))
+    summary = coord.run()
+    assert summary["rows"] == len(rows)
+
+    p = (
+        tmp_path
+        / "data"
+        / "symbol=AAPL"
+        / "year=2023"
+        / "month=01"
+        / "day=02.parquet"
+    )
+    assert p.exists()
+    table = pq.ParquetFile(p).read()
+    assert table.num_rows == len(rows)
+    assert set(table.column("schema_version").to_pylist()) == {1}
+
+    # second run should skip because checkpoint saved
+    summary2 = coord.run()
+    assert summary2["rows"] == 0
+


### PR DESCRIPTION
## Summary
- build threaded ingestion coordinator using AlpacaClient
- validate rows via new SchemaValidator
- write results to partitioned Parquet
- checkpoint progress in SQLite
- expose CLI `marketpipe ingest --config ...`
- provide example config and docs diagram
- add integration test for coordinator flow

## Testing
- `pip install -e .`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421d98de6083238f1243768f337fd7