### PR TITLE
Fix missing httpx dependency and update tests

### DIFF
--- a/examples/alpaca_iex_test.py
+++ b/examples/alpaca_iex_test.py
@@ -14,6 +14,10 @@ load_dotenv()
 alpaca_key = os.environ.get('ALPACA_KEY')
 alpaca_secret = os.environ.get('ALPACA_SECRET')
 
+if not alpaca_key or not alpaca_secret:
+    import pytest
+    pytest.skip("ALPACA credentials not set", allow_module_level=True)
+
 print(f"🔑 Testing IEX endpoints with credentials: {alpaca_key[:8]}... / {alpaca_secret[:8]}...")
 
 async def test_iex_endpoints():

--- a/examples/alpaca_simple_test.py
+++ b/examples/alpaca_simple_test.py
@@ -13,6 +13,10 @@ load_dotenv()
 alpaca_key = os.environ.get('ALPACA_KEY')
 alpaca_secret = os.environ.get('ALPACA_SECRET')
 
+if not alpaca_key or not alpaca_secret:
+    import pytest
+    pytest.skip("ALPACA credentials not set", allow_module_level=True)
+
 print(f"🔑 Testing with credentials: {alpaca_key[:8]}... / {alpaca_secret[:8]}...")
 
 async def test_basic_endpoints():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ dependencies = [
     "duckdb",
     "pyarrow",
     "requests",
-    "pyyaml"
+    "pyyaml",
+    "httpx",
+    "prometheus_client",
+    "python-dotenv"
 ]
 
 [project.scripts]
 marketpipe = "marketpipe.cli:app"
 
-[tool.poetry.dependencies]
-prometheus_client = "*"

--- a/tests/test_coordinator_flow.py
+++ b/tests/test_coordinator_flow.py
@@ -58,6 +58,9 @@ def test_coordinator_flow(tmp_path, monkeypatch):
         fake_fetch,
     )
 
+    monkeypatch.setenv("ALPACA_KEY", "k")
+    monkeypatch.setenv("ALPACA_SECRET", "s")
+
     coord = IngestionCoordinator(str(cfg_file), state_path=str(tmp_path / "state.db"))
     summary = coord.run()
     assert summary["rows"] == len(rows)


### PR DESCRIPTION
## Summary
- ensure required packages like `httpx`, `prometheus_client`, and `python-dotenv` are installed by default
- skip Alpaca example tests when credentials aren't available
- patch coordinator test to set dummy Alpaca environment vars

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433227c6e8832385104874bef479a5