### PR TITLE
Remove placeholder stub modules - Delete src/marketpipe/loader.py, ag…

### DIFF
--- a/src/marketpipe/__init__.py
+++ b/src/marketpipe/__init__.py
@@ -3,9 +3,6 @@
 __all__ = [
     "cli",
     "ingestion",
-    "aggregation",
-    "validation",
-    "loader",
     "metrics",
     "metrics_server",
 ]

--- a/src/marketpipe/aggregation.py
+++ b/src/marketpipe/aggregation.py
@@ -1,6 +1,0 @@
-"""Aggregation stubs."""
-
-
-def aggregate() -> None:
-    """Placeholder for aggregation step."""
-    print("Aggregating raw data ...")

--- a/src/marketpipe/cli.py
+++ b/src/marketpipe/cli.py
@@ -1,7 +1,7 @@
 """Command line interface for MarketPipe."""
 
 import typer
-from . import ingestion, aggregation, validation
+from . import ingestion
 from .metrics_server import run as metrics_server_run
 
 app = typer.Typer(add_completion=False, help="MarketPipe ETL commands")
@@ -11,18 +11,6 @@ app = typer.Typer(add_completion=False, help="MarketPipe ETL commands")
 def ingest(config: str = typer.Option(..., "--config", help="Path to YAML config")):
     """Run the ingestion pipeline."""
     ingestion.ingest(config)
-
-
-@app.command()
-def aggregate():
-    """Aggregate raw data into coarser time frames."""
-    aggregation.aggregate()
-
-
-@app.command()
-def validate():
-    """Validate aggregated data against a reference API."""
-    validation.validate()
 
 
 @app.command()

--- a/src/marketpipe/loader.py
+++ b/src/marketpipe/loader.py
@@ -1,6 +1,0 @@
-"""Loader stubs."""
-
-
-def load_ohlcv(symbol: str):
-    """Placeholder for loading data from DuckDB/Parquet."""
-    print(f"Loading data for {symbol} ...")

--- a/src/marketpipe/validation.py
+++ b/src/marketpipe/validation.py
@@ -1,6 +1,0 @@
-"""Validation stubs."""
-
-
-def validate() -> None:
-    """Placeholder for validation step."""
-    print("Validating data against Polygon API ...")


### PR DESCRIPTION
…gregation.py, validation.py - Remove stub imports from __init__.py and cli.py - Remove 'aggregate' and 'validate' CLI commands - These were inert placeholder modules that were never implemented - CLI now only shows working commands: ingest and metrics - All existing tests continue to pass