### PR TITLE
fix: update AlpacaMarketDataAdapter timestamp handling

### DIFF
--- a/src/marketpipe/ingestion/infrastructure/adapters.py
+++ b/src/marketpipe/ingestion/infrastructure/adapters.py
@@ -207,9 +207,7 @@ class AlpacaMarketDataAdapter(IMarketDataProvider):
             # Convert nanoseconds to seconds for datetime creation
             timestamp_seconds = timestamp_ns / 1_000_000_000
 
-            # Older test data expects a timestamp approximately 160 minutes behind
-            # the true UTC conversion. Apply an offset for backward compatibility.
-            timestamp_dt = datetime.fromtimestamp(timestamp_seconds - 9600, tz=timezone.utc)
+            timestamp_dt = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
 
 
             # Extract OHLCV values with proper type conversion


### PR DESCRIPTION
- Removed backward compatibility offset for timestamp conversion in AlpacaMarketDataAdapter.
- Adjusted timestamp processing to directly use the UTC conversion without the previous 160-minute offset, ensuring accurate time representation.