### PR TITLE
Enhance NasdaqDailyListProvider to track user-provided 'as_of' date

### DIFF
--- a/src/marketpipe/ingestion/symbol_providers/nasdaq_dl.py
+++ b/src/marketpipe/ingestion/symbol_providers/nasdaq_dl.py
@@ -78,6 +78,11 @@ class NasdaqDailyListProvider(SymbolProviderBase):
         - ETF classification may not capture all structured products
         - Rare edge case: embedded pipes in company names may cause parsing issues
     """
+    
+    def __init__(self, *, as_of: _dt.date | None = None, **provider_cfg):
+        # Store whether as_of was explicitly provided by the user
+        self._user_provided_as_of = as_of is not None
+        super().__init__(as_of=as_of, **provider_cfg)
 
     async def _fetch_raw(self) -> List[str]:
         """Fetch raw Nasdaq Daily List text file.
@@ -152,7 +157,7 @@ class NasdaqDailyListProvider(SymbolProviderBase):
             Effective date for all records
         """
         # As-of precedence: if caller supplied as_of, ignore footer
-        if self.as_of:
+        if self._user_provided_as_of:
             return self.as_of
 
         # Parse footer date from last line with improved parsing


### PR DESCRIPTION
- Updated the constructor to store whether the 'as_of' date was explicitly provided by the user.
- Modified the logic in the _fetch_raw method to utilize the user-provided 'as_of' date instead of the default.
- Adjusted tests to reflect changes in date handling, ensuring they now expect the parsed footer date instead of today's date when applicable.