### PR TITLE
fix: add missing f-string prefix for dashboard URL

### DIFF
--- a/src/marketpipe/cli/utils.py
+++ b/src/marketpipe/cli/utils.py
@@ -57,7 +57,7 @@ def metrics(
                 print(
                     f"📊 Starting legacy metrics server on http://localhost:{port}/metrics"
                 )
-                print("📋 Human-friendly dashboard will be available at http://localhost:{port+1}")
+                print(f"📋 Human-friendly dashboard will be available at http://localhost:{port+1}")
                 print("Press Ctrl+C to stop the server")
                 metrics_server_run(port=port, legacy=True)
             else:


### PR DESCRIPTION
Simple fix for missing f-string prefix in legacy metrics command that was causing literal {port+1} to be printed instead of the actual port number.

This ensures the dashboard URL is properly formatted when the legacy metrics server is started.