### PR TITLE
fix: correct prune command test expectation in CLI matrix tests

### DIFF
--- a/tests/integration/test_cli_enhanced_matrix.py
+++ b/tests/integration/test_cli_enhanced_matrix.py
@@ -677,7 +677,7 @@ class TestEnhancedCLIMatrix:
             EdgeCaseTest(
                 command_path=["prune", "parquet"],
                 test_name="prune_with_dry_run",
-                options={"--dry-run": True},
+                options={"--dry-run": True, "--root": "/nonexistent/parquet/path"},
                 positional_args=["30d"],
                 expected_exit_code=1,
                 expected_error_patterns=["directory", "does not exist"],


### PR DESCRIPTION
## Summary
Fixes a failing test in `test_cli_enhanced_matrix.py` where the prune command test had incorrect expectations.

## Problem
The test `test_command_option_combinations` was failing because it expected the prune command to fail (exit code 1) when running with default directory, but the command was correctly succeeding (exit code 0) because files actually exist in the default `data/parquet` directory.

## Solution
Updated the test to use a non-existent directory path (`/nonexistent/parquet/path`) with the `--root` option to properly test error handling for missing directories.

## Changes
- Modified `prune_with_dry_run` test case to use `--root /nonexistent/parquet/path`
- Test now correctly expects exit code 1 for non-existent directory
- Verifies proper error message: "directory does not exist"

## Testing
✅ Test now passes and correctly validates error handling behavior
✅ Command behavior remains correct for valid directories

🤖 Generated with [Claude Code](https://claude.ai/code)