### PR TITLE
fix: update unit tests to match current validation behavior

### DIFF
--- a/tests/unit/cli/test_ingest_cli_config.py
+++ b/tests/unit/cli/test_ingest_cli_config.py
@@ -250,7 +250,7 @@ end: 2025-01-07
             result = runner.invoke(app, ["ingest-ohlcv", "--config", temp_path])
 
             assert result.exit_code == 2
-            assert "invalid YAML in config file" in result.stderr
+            assert "invalid YAML in config file" in result.output
         finally:
             os.unlink(temp_path)
 

--- a/tests/unit/config/test_ingestion_config.py
+++ b/tests/unit/config/test_ingestion_config.py
@@ -74,13 +74,13 @@ class TestIngestionJobConfig:
         # Invalid symbol format
         with pytest.raises(ValueError, match="Invalid symbol format"):
             IngestionJobConfig(
-                symbols=["AAP1"],  # Contains number
+                symbols=["AAP@"],  # Contains invalid character
                 start=date(2025, 1, 1),
                 end=date(2025, 1, 7),
             )
 
         # Symbol too long
-        with pytest.raises(ValueError, match="Symbol too long"):
+        with pytest.raises(ValueError, match="Invalid symbol format"):
             IngestionJobConfig(
                 symbols=["VERYLONGSYMBOL"], start=date(2025, 1, 1), end=date(2025, 1, 7)
             )


### PR DESCRIPTION
## Summary
Updates unit tests to align with current validation behavior after recent changes to symbol validation and error handling.

## Fixes Applied

### 1. CLI Config Test (test_invalid_yaml_syntax_error)
- **Issue**: Test was checking `result.stderr` but stderr wasn't captured separately
- **Fix**: Changed to check `result.output` instead
- **Test**: `tests/unit/cli/test_ingest_cli_config.py`

### 2. Symbol Validation Test (test_invalid_symbols)
- **Issue**: Symbol validation logic was updated to allow A-Z, 0-9, and dots
- **Problem**: Test used "AAP1" (now valid) and expected "Symbol too long" message (now says "Invalid symbol format")
- **Fixes**:
  - Changed invalid symbol from "AAP1" to "AAP@" (@ is actually invalid)
  - Updated error message expectation for long symbols to match current validation

## Testing
✅ All unit tests now pass (434 passed, 1 skipped)
✅ Key integration tests verified
✅ CLI matrix tests confirmed working
✅ Symbol validation properly tested with actually invalid characters

## Background
These test updates were needed after improvements to:
- Symbol validation regex patterns
- Error message consistency
- CLI error handling and output capture

🤖 Generated with [Claude Code](https://claude.ai/code)